### PR TITLE
Fix undefined query params

### DIFF
--- a/frontend/src/services/fileService.ts
+++ b/frontend/src/services/fileService.ts
@@ -17,7 +17,10 @@ export const fileService = {
   },
 
   async getFiles(params: FileQueryParams = {}): Promise<FileType[]> {
-    const response = await axios.get(`${API_URL}/files/`, { params });
+    const cleanedParams = Object.fromEntries(
+      Object.entries(params).filter(([_, v]) => v !== undefined)
+    );
+    const response = await axios.get(`${API_URL}/files/`, { params: cleanedParams });
     return response.data;
   },
 


### PR DESCRIPTION
## Summary
- filter out `undefined` values from query params in fileService

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6847d7049104832ab0bd32f0873766ad