### PR TITLE
Standardize bytes unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ docker-compose up --build
   - `search`: search by filename
   - `file_type`: filter by MIME type
   - `size_min` / `size_max`: size range in bytes
+  - All file sizes returned by the API and displayed in the UI are measured in bytes
   - `date_from` / `date_to`: upload date range (YYYY-MM-DD)
 - Returns a list of all uploaded files
 - Response includes file metadata (name, size, type, upload date)

--- a/frontend/src/components/FileList.tsx
+++ b/frontend/src/components/FileList.tsx
@@ -112,7 +112,7 @@ export const FileList: React.FC = () => {
         />
         <input
           type="number"
-          placeholder="Min KB"
+          placeholder="Min bytes"
           value={filters.size_min ?? ''}
           onChange={(e) =>
             setFilters({
@@ -124,7 +124,7 @@ export const FileList: React.FC = () => {
         />
         <input
           type="number"
-          placeholder="Max KB"
+          placeholder="Max bytes"
           value={filters.size_max ?? ''}
           onChange={(e) =>
             setFilters({
@@ -150,7 +150,7 @@ export const FileList: React.FC = () => {
 
       {typeof savings?.storage_savings === 'number' && (
         <div className="text-sm text-gray-600 mb-2">
-          Storage saved: {(savings.storage_savings / 1024).toFixed(2)} KB
+          Storage saved: {savings.storage_savings} bytes
         </div>
       )}
       {!files || files.length === 0 ? (
@@ -175,7 +175,7 @@ export const FileList: React.FC = () => {
                       {file.original_filename}
                     </p>
                     <p className="text-sm text-gray-500">
-                      {file.file_type} • {(file.size / 1024).toFixed(2)} KB
+                      {file.file_type} • {file.size} bytes
                     </p>
                     <p className="text-sm text-gray-500">
                       Uploaded {new Date(file.uploaded_at).toLocaleString()}


### PR DESCRIPTION
## Summary
- use bytes consistently in placeholders and display
- document that file sizes are measured in bytes

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_b_6847d77892fc832a8f891f6187e2529c